### PR TITLE
create qsv_docopt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "docopt"
+name = "qsv_docopt"
 version = "1.1.1"  #:version
-authors = ["Andrew Gallant <jamslam@gmail.com>"]
+authors = ["Andrew Gallant <jamslam@gmail.com>", "Joel Natividad <joel@datHere.com>"]
 description = "Command line argument parsing."
-documentation = "http://burntsushi.net/rustdoc/docopt/"
-homepage = "https://github.com/docopt/docopt.rs"
-repository = "https://github.com/docopt/docopt.rs"
+documentation = "https://docs.rs/qsv_docopt"
+homepage = "https://github.com/jqnatividad/docopt.rs"
+repository = "https://github.com/jqnatividad/docopt.rs"
 readme = "README.md"
 keywords = ["docopt", "argument", "command", "argv"]
 categories = ["command-line-interface"]
@@ -14,10 +14,10 @@ exclude = ["/.travis.yml", "/Makefile", "/ctags.rust", "/scripts/*", "/session.v
 edition = "2021"
 
 [lib]
-name = "docopt"
+name = "qsv_docopt"
 
 [[bin]]
-name = "docopt-wordlist"
+name = "qsv-docopt-wordlist"
 path = "src/wordlist.rs"
 doc = false
 test = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ test = false
 
 [dependencies]
 lazy_static = "1.4"
-regex = { version = "1.7", default-features = false, features = ["std", "unicode"] }
+regex = { version = "1.7", default-features = false, features = ["std", "unicode", "perf"] }
 serde = { version = "1", features = ["derive"] }
 strsim = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["docopt", "argument", "command", "argv"]
 categories = ["command-line-interface"]
 license = "Unlicense/MIT"
 exclude = ["/.travis.yml", "/Makefile", "/ctags.rust", "/scripts/*", "/session.vim"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "docopt"
@@ -23,7 +23,7 @@ doc = false
 test = false
 
 [dependencies]
-lazy_static = "1.3"
-regex = { version = "1.4.0", default-features = false, features = ["std", "unicode"] }
-serde = { version = "1.0", features = ["derive"] }
+lazy_static = "1.4"
+regex = { version = "1.5", default-features = false, features = ["std", "unicode"] }
+serde = { version = "1", features = ["derive"] }
 strsim = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ test = false
 
 [dependencies]
 lazy_static = "1.4"
-regex = { version = "1.5", default-features = false, features = ["std", "unicode"] }
+regex = { version = "1.7", default-features = false, features = ["std", "unicode"] }
 serde = { version = "1", features = ["derive"] }
 strsim = "0.10"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-# THIS CRATE IS UNMAINTAINED
+# qsv_docopt
 
-This crate is unlikely to see significant future evolution. The primary reason
-to choose this crate for a new project is if you're specifically interested in
-using [docopt](http://docopt.org/) syntax for your project. However, the wider
-docopt project is mostly unmaintained at this point.
+This crate is primarily maintained for the qsv project as its been optimized to
+take advantage of the self-documenting nature of [docopt](http://docopt.org/),
+which [clap](http://docs.rs/clap/) or [structopt](http://docs.rs/structopt/)
+does not provide.
 
-Consider using [clap](http://docs.rs/clap/) or possibly
-[structopt](http://docs.rs/structopt/) instead.
-
-Note that this crate has some significant bugs. The two biggest ones are the
-lack of `OsStr` support and some severe performance problems in not-uncommon
-edge cases.
+As the [docopt.rs](https://github.com/docopt/docopt.rs) project is no longer maintained,
+this crate will be updated as necessary to ensure qsv uses the latest
+features/innovations of Rust with this qsv-optimized version of docopt.
 
 docopt
 ======
@@ -28,7 +25,7 @@ Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).
 
 ### Documentation
 
-https://docs.rs/docopt
+https://docs.rs/qsv_docopt
 
 
 ### Installation
@@ -37,7 +34,7 @@ This crate is fully compatible with Cargo. Just add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-docopt = "1"
+qsv_docopt = "1"
 serde = { version = "1", features = ["derive"] }
 ```
 
@@ -49,7 +46,7 @@ of the named values in the Docopt usage string. Values will be automatically
 converted to those types (or an error will be reported).
 
 ```rust
-use docopt::Docopt;
+use qsv_docopt::Docopt;
 use serde::Deserialize;
 
 const USAGE: &'static str = "
@@ -113,7 +110,7 @@ like `<arg>` or `--flag`. If you prefer this access pattern, then you can use
 conversion manually. Here's the canonical Docopt example with a hash table:
 
 ```rust
-use docopt::Docopt;
+use qsv_docopt::Docopt;
 
 const USAGE: &'static str = "
 Naval Fate.

--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -2,7 +2,7 @@ use docopt::Docopt;
 use serde::Deserialize;
 
 // Write the Docopt usage string.
-const USAGE: &'static str = "
+const USAGE: &str = "
 Rust's package manager
 
 Usage:

--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -1,4 +1,4 @@
-use docopt::Docopt;
+use qsv_docopt::Docopt;
 use serde::Deserialize;
 
 // Write the Docopt usage string.

--- a/examples/cp.rs
+++ b/examples/cp.rs
@@ -1,4 +1,4 @@
-use docopt::Docopt;
+use qsv_docopt::Docopt;
 use serde::Deserialize;
 
 // Write the Docopt usage string.

--- a/examples/cp.rs
+++ b/examples/cp.rs
@@ -2,7 +2,7 @@ use docopt::Docopt;
 use serde::Deserialize;
 
 // Write the Docopt usage string.
-const USAGE: &'static str = "
+const USAGE: &str = "
 Usage: cp [-a] <source> <dest>
        cp [-a] <source>... <dir>
 

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,4 +1,4 @@
-use docopt::Docopt;
+use qsv_docopt::Docopt;
 use serde::Deserialize;
 
 const USAGE: &str = "

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,7 +1,7 @@
 use docopt::Docopt;
 use serde::Deserialize;
 
-const USAGE: &'static str = "
+const USAGE: &str = "
 Naval Fate.
 
 Usage:

--- a/examples/hashmap.rs
+++ b/examples/hashmap.rs
@@ -1,4 +1,4 @@
-use docopt::Docopt;
+use qsv_docopt::Docopt;
 
 const USAGE: &str = "
 Naval Fate.

--- a/examples/hashmap.rs
+++ b/examples/hashmap.rs
@@ -1,6 +1,6 @@
 use docopt::Docopt;
 
-const USAGE: &'static str = "
+const USAGE: &str = "
 Naval Fate.
 
 Usage:

--- a/examples/optional_command.rs
+++ b/examples/optional_command.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 
-use docopt::Docopt;
+use qsv_docopt::Docopt;
 use serde::{Deserialize, de::{Deserializer, Error, Visitor}};
 
 // Write the Docopt usage string.

--- a/examples/optional_command.rs
+++ b/examples/optional_command.rs
@@ -10,7 +10,7 @@ use docopt::Docopt;
 use serde::{Deserialize, de::{Deserializer, Error, Visitor}};
 
 // Write the Docopt usage string.
-const USAGE: &'static str = "
+const USAGE: &str = "
 Rust's package manager
 
 Usage:

--- a/examples/verbose_multiple.rs
+++ b/examples/verbose_multiple.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 // explicitly.
 //
 // This is unfortunate.
-const USAGE: &'static str = "
+const USAGE: &str = "
 Usage: cp [options] [-v | -vv | -vvv] <source> <dest>
        cp [options] [-v | -vv | -vvv] <source>... <dir>
 

--- a/examples/verbose_multiple.rs
+++ b/examples/verbose_multiple.rs
@@ -1,4 +1,4 @@
-use docopt::Docopt;
+use qsv_docopt::Docopt;
 use serde::Deserialize;
 
 // This shows how to implement multiple levels of verbosity.

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -516,7 +516,7 @@ impl fmt::Debug for ArgvMap {
         keys.sort();
         let mut first = true;
         for &k in &keys {
-            if !first { writeln!(f)?; } else { first = false; }
+            if first { first = false; } else { writeln!(f)?; }
             match reverse.get(&k) {
                 None => {
                     write!(f, "{} => {:?}", k, self.map.get(k))?

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -220,7 +220,7 @@ impl Docopt {
     pub fn parse(&self) -> Result<ArgvMap> {
         let argv = self.argv.clone().unwrap_or_else(Docopt::get_argv);
         let vals =
-            self.p.parse_argv(argv, self.options_first)
+            self.p.parse_argv(&argv, self.options_first)
                 .map_err(|s| self.err_with_usage(Argv(s)))
                 .and_then(|argv|
                     match self.p.matches(&argv) {

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -200,7 +200,7 @@ impl Docopt {
     pub fn deserialize<'a, 'de: 'a, D>(&'a self) -> Result<D>
         where D: de::Deserialize<'de>
     {
-        self.parse().and_then(|vals| vals.deserialize())
+        self.parse().and_then(dopt::ArgvMap::deserialize)
     }
 
     /// Parse command line arguments and try to match them against a usage

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -456,7 +456,7 @@ impl ArgvMap {
                 } else if !cmd.is_empty() {
                     ("cmd_", cmd)
                 } else {
-                    panic!("Unknown ArgvMap key: '{}'", name)
+                    panic!("Unknown ArgvMap key: '{name}'")
                 };
             let mut prefix = prefix.to_owned();
             prefix.push_str(&sanitize(name));
@@ -496,7 +496,7 @@ impl ArgvMap {
             } else if field.starts_with("cmd_") {
                 CMD.replace(field, "").into_owned()
             } else {
-                panic!("Unrecognized struct field: '{}'", field)
+                panic!("Unrecognized struct field: '{field}'")
             };
         desanitize(&name)
     }

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -113,7 +113,7 @@ impl Error {
             werr!("{}\n", self);
             ::std::process::exit(1)
         } else {
-            let _ = writeln!(&mut io::stdout(), "{}", self);
+            let _ = writeln!(&mut io::stdout(), "{self}");
             ::std::process::exit(0)
         }
     }
@@ -127,9 +127,9 @@ impl fmt::Display for Error {
             WithProgramUsage(ref other, ref usage) => {
                 let other = other.to_string();
                 if other.is_empty() {
-                    write!(f, "{}", usage)
+                    write!(f, "{usage}")
                 } else {
-                    write!(f, "{}\n\n{}", other, usage)
+                    write!(f, "{other}\n\n{usage}")
                 }
             }
             Help => write!(f, ""),
@@ -137,7 +137,7 @@ impl fmt::Display for Error {
             Usage(ref s) |
             Argv(ref s) |
             Deserialize(ref s) |
-            Version(ref s) => write!(f, "{}", s),
+            Version(ref s) => write!(f, "{s}"),
         }
     }
 }

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -200,7 +200,7 @@ impl Docopt {
     pub fn deserialize<'a, 'de: 'a, D>(&'a self) -> Result<D>
         where D: de::Deserialize<'de>
     {
-        self.parse().and_then(dopt::ArgvMap::deserialize)
+        self.parse().and_then(ArgvMap::deserialize)
     }
 
     /// Parse command line arguments and try to match them against a usage
@@ -388,25 +388,25 @@ impl ArgvMap {
     /// Finds the value corresponding to `key` and calls `as_bool()` on it.
     /// If the key does not exist, `false` is returned.
     pub fn get_bool(&self, key: &str) -> bool {
-        self.find(key).map_or(false, |v| v.as_bool())
+        self.find(key).map_or(false, Value::as_bool)
     }
 
     /// Finds the value corresponding to `key` and calls `as_count()` on it.
     /// If the key does not exist, `0` is returned.
     pub fn get_count(&self, key: &str) -> u64 {
-        self.find(key).map_or(0, |v| v.as_count())
+        self.find(key).map_or(0, Value::as_count)
     }
 
     /// Finds the value corresponding to `key` and calls `as_str()` on it.
     /// If the key does not exist, `""` is returned.
     pub fn get_str(&self, key: &str) -> &str {
-        self.find(key).map_or("", |v| v.as_str())
+        self.find(key).map_or("", Value::as_str)
     }
 
     /// Finds the value corresponding to `key` and calls `as_vec()` on it.
     /// If the key does not exist, `vec!()` is returned.
     pub fn get_vec(&self, key: &str) -> Vec<&str> {
-        self.find(key).map(|v| v.as_vec()).unwrap_or_default()
+        self.find(key).map(Value::as_vec).unwrap_or_default()
     }
 
     /// Return the raw value corresponding to some `key`.

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -519,10 +519,10 @@ impl fmt::Debug for ArgvMap {
             if first { first = false; } else { writeln!(f)?; }
             match reverse.get(&k) {
                 None => {
-                    write!(f, "{} => {:?}", k, self.map.get(k))?
+                    write!(f, "{k} => {:?}", self.map.get(k))?
                 }
                 Some(s) => {
-                    write!(f, "{}, {} => {:?}", s, k, self.map.get(k))?
+                    write!(f, "{s}, {k} => {:?}", self.map.get(k))?
                 }
             }
         }

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -904,14 +904,8 @@ impl<'a, 'de> ::serde::Deserializer<'de> for &'a mut Deserializer<'de> {
         where V: de::Visitor<'de>
     {
         let v = self.pop_val()?.as_str().to_lowercase();
-        let s = match variants.iter().find(|&n| n.to_lowercase() == v) {
-            Some(s) => s,
-            None => {
-                derr!("Could not match '{}' with any of \
-                           the allowed variants: {:?}",
-                      v,
-                      variants)
-            }
+        let Some(s) = variants.iter().find(|&n| n.to_lowercase() == v) else {
+            derr!("Could not match '{v}' with any of the allowed variants: {variants:?}")
         };
         visitor.visit_enum(s.into_deserializer())
     }

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -179,7 +179,7 @@ impl Docopt {
     /// is returned.
     pub fn new<S>(usage: S) -> Result<Docopt>
             where S: ::std::ops::Deref<Target=str> {
-        Parser::new(usage.deref())
+        Parser::new(&usage)
                .map_err(Usage)
                .map(|p| Docopt {
                    p,

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -820,7 +820,7 @@ impl<'a, 'de> ::serde::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         let is_some = match self.stack.last() {
             None => derr!("Could not deserialize value into unknown key."),
-            Some(it) => it.val.as_ref().map_or(false, |v| v.as_bool()),
+            Some(it) => it.val.as_ref().map_or(false, Value::as_bool),
         };
         if is_some {
             visitor.visit_some(self)

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -34,7 +34,7 @@ use crate::cap_or_empty;
 /// in that process. This can be achieved like so:
 ///
 /// ```no_run
-/// use docopt::Docopt;
+/// use qsv_docopt::Docopt;
 ///
 /// const USAGE: &'static str = "
 /// Usage: ...
@@ -346,7 +346,7 @@ impl ArgvMap {
     /// # fn main() {
     /// use serde::Deserialize;
     ///
-    /// use docopt::Docopt;
+    /// use qsv_docopt::Docopt;
     ///
     /// const USAGE: &'static str = "
     /// Usage: cargo [options] (build | test)
@@ -623,14 +623,14 @@ impl Value {
 /// and produces a deserializable value:
 ///
 /// ```rust
-/// # extern crate docopt;
+/// # extern crate qsv_docopt;
 /// extern crate serde;
 /// # fn main() {
-/// use docopt::Docopt;
+/// use qsv_docopt::Docopt;
 /// use serde::de::Deserialize;
 ///
 /// fn deserialize<'de, D: Deserialize<'de>>(usage: &str, argv: &[&str])
-///                         -> Result<D, docopt::Error> {
+///                         -> Result<D, qsv_docopt::Error> {
 ///     Docopt::new(usage)
 ///            .and_then(|d| d.argv(argv.iter()).deserialize())
 /// }

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -481,7 +481,7 @@ impl ArgvMap {
                 let name = FLAG.replace(field, "");
                 let mut pre_name = (if name.len() == 1 { "-" } else { "--" })
                                    .to_owned();
-                pre_name.push_str(&*name);
+                pre_name.push_str(&name);
                 pre_name
             } else if field.starts_with("arg_") {
                 let name = ARG.replace(field, "").into_owned();
@@ -489,7 +489,7 @@ impl ArgvMap {
                     name
                 } else {
                     let mut pre_name = "<".to_owned();
-                    pre_name.push_str(&*name);
+                    pre_name.push_str(&name);
                     pre_name.push('>');
                     pre_name
                 }
@@ -498,7 +498,7 @@ impl ArgvMap {
             } else {
                 panic!("Unrecognized struct field: '{}'", field)
             };
-        desanitize(&*name)
+        desanitize(&name)
     }
 }
 
@@ -598,7 +598,7 @@ impl Value {
     pub fn as_str(&self) -> &str {
         match *self {
             Switch(_) | Counted(_) | Plain(None) | List(_) => "",
-            Plain(Some(ref s)) => &**s,
+            Plain(Some(ref s)) => s,
         }
     }
 
@@ -658,7 +658,7 @@ impl<'de> Deserializer<'de> {
             .push(DeserializerItem {
                       key: key.clone(),
                       struct_field,
-                      val: self.vals.find(&*key).cloned(),
+                      val: self.vals.find(&key).cloned(),
                   });
     }
 

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -584,7 +584,7 @@ impl Value {
     /// Lists correspond to its length.
     pub fn as_count(&self) -> u64 {
         match *self {
-            Switch(b) => if b { 1 } else { 0 },
+            Switch(b) => u64::from(b), // if b { 1 } else { 0 },
             Counted(n) => n,
             Plain(None) => 0,
             Plain(Some(_)) => 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! usage string. Here's a simple example:
 //!
 //! ```rust
-//! use docopt::Docopt;
+//! use qsv_docopt::Docopt;
 //!
 //! // Write the Docopt usage string.
 //! const USAGE: &'static str = "
@@ -47,7 +47,7 @@
 //!
 //! ```rust
 //! # fn main() {
-//! use docopt::Docopt;
+//! use qsv_docopt::Docopt;
 //! use serde::Deserialize;
 //!
 //! // Write the Docopt usage string.
@@ -93,7 +93,7 @@
 //!
 //! use serde::Deserialize;
 //!
-//! use docopt::Docopt;
+//! use qsv_docopt::Docopt;
 //!
 //! // Write the Docopt usage string.
 //! const USAGE: &'static str = "
@@ -180,8 +180,8 @@
 //! # }
 //! ```
 
-#![crate_name = "docopt"]
-#![doc(html_root_url = "http://burntsushi.net/rustdoc/docopt")]
+#![crate_name = "qsv_docopt"]
+// #![doc(html_root_url = "http://burntsushi.net/rustdoc/docopt")]
 #![deny(missing_docs)]
 
 pub use crate::dopt::{ArgvMap, Deserializer, Docopt, Error, Value};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -490,9 +490,7 @@ impl<'a> PatParser<'a> {
 
             // The only way for a short option to have an argument is if
             // it's specified in an option description.
-            if !self.dopt.has_arg(&atom) {
-                self.add_atom_ifnotexists(Zero, &atom);
-            } else {
+            if self.dopt.has_arg(&atom) {
                 // At this point, the flag MUST have an argument. Therefore,
                 // we interpret the "rest" of the characters as the argument.
                 // If the "rest" is empty, then we peek to find and make sure
@@ -506,6 +504,8 @@ impl<'a> PatParser<'a> {
                 // We either error'd or consumed the rest of the short stack as
                 // an argument.
                 break
+            } else {
+                self.add_atom_ifnotexists(Zero, &atom);
             }
         }
         self.next();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -94,7 +94,7 @@ impl Parser {
         None
     }
 
-    pub fn parse_argv(&self, argv: Vec<String>, options_first: bool)
+    pub fn parse_argv(&self, argv: &[String], options_first: bool)
                          -> Result<Argv<'_>, String> {
         Argv::new(self, &argv, options_first)
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -38,7 +38,6 @@
 //
 //   - Write a specification for Docopt.
 
-use std::borrow::ToOwned;
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry::{Vacant, Occupied};
 use std::cmp::Ordering;
@@ -1260,7 +1259,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                 (true, &One(Some(ref v))) => {
                     let words = SPLIT_SPACE
                                 .split(v)
-                                .map(|s| s.to_owned())
+                                .map(std::borrow::ToOwned::to_owned)
                                 .collect();
                     vs.insert(atom, List(words));
                 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -279,8 +279,7 @@ impl Parser {
         let opts =
             self.descs
             .find_mut(last_atom)
-            .unwrap_or_else(|| panic!("BUG: last opt desc key ('{:?}') is invalid.",
-                                       last_atom));
+            .unwrap_or_else(|| panic!("BUG: last opt desc key ('{last_atom:?}') is invalid."));
         match opts.arg {
             One(None) => {}, // OK
             Zero =>
@@ -342,19 +341,19 @@ impl fmt::Debug for Parser {
         writeln!(f, "Option descriptions:")?;
         let keys = sorted(self.descs.keys().collect());
         for &k in &keys {
-            writeln!(f, "  '{}' => {:?}", k, self.descs.get(k))?;
+            writeln!(f, "  '{k}' => {:?}", self.descs.get(k))?;
         }
 
         writeln!(f, "Synonyms:")?;
         let keys: Vec<(&Atom, &Atom)> =
             sorted(self.descs.synonyms().collect());
         for &(from, to) in &keys {
-            writeln!(f, "  {:?} => {:?}", from, to)?;
+            writeln!(f, "  {from:?} => {to:?}")?;
         }
 
         writeln!(f, "Usages:")?;
         for pat in &self.usages {
-            writeln!(f, "  {:?}", pat)?;
+            writeln!(f, "  {pat:?}")?;
         }
         writeln!(f, "=====")
     }
@@ -555,7 +554,7 @@ impl<'a> PatParser<'a> {
     }
 
     fn next_flag_arg(&mut self, atom: &Atom) -> Result<(), String> {
-        self.next_noeof(&format!("argument for flag '{}'", atom))?;
+        self.next_noeof(&format!("argument for flag '{atom}'"))?;
         self.errif_invalid_flag_arg(atom, self.cur())
     }
 
@@ -783,7 +782,7 @@ impl Atom {
         } else if Atom::is_cmd(s) {
             Command(s.into())
         } else {
-            panic!("Unknown atom string: '{}'", s)
+            panic!("Unknown atom string: '{s}'")
         }
     }
 
@@ -848,14 +847,14 @@ impl PartialOrd for Atom {
 impl fmt::Display for Atom {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Short(c) => write!(f, "-{}", c),
-            Long(ref s) => write!(f, "--{}", s),
-            Command(ref s) => write!(f, "{}", s),
+            Short(c) => write!(f, "-{c}"),
+            Long(ref s) => write!(f, "--{s}"),
+            Command(ref s) => write!(f, "{s}"),
             Positional(ref s) => {
                 if s.chars().all(char::is_uppercase) {
-                    write!(f, "{}", s)
+                    write!(f, "{s}")
                 } else {
-                    write!(f, "<{}>", s)
+                    write!(f, "<{s}>")
                 }
             }
         }
@@ -1038,7 +1037,7 @@ impl<'a> Argv<'a> {
         }
     }
     fn next_arg(&mut self, atom: &Atom) -> Result<&str, String> {
-        let expected = format!("argument for flag '{}'", atom);
+        let expected = format!("argument for flag '{atom}'");
         self.next_noeof(&expected)?;
         Ok(self.cur())
     }
@@ -1111,7 +1110,7 @@ impl MState {
     fn add_value(&mut self, opts: &Options,
                  spec: &Atom, atom: &Atom, arg: &Option<String>) -> bool {
         assert!(opts.arg.has_arg() == arg.is_some(),
-                "'{:?}' should have an argument but doesn't", atom);
+                "'{atom:?}' should have an argument but doesn't");
         match *atom {
             Short(_) | Long(_) => {
                 self.fill_value(spec.clone(), opts.repeats, arg.clone())

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -639,6 +639,7 @@ enum Pattern {
     PatAtom(Atom),
 }
 
+#[allow(clippy::derive_ord_xor_partial_ord)]
 #[derive(PartialEq, Eq, Ord, Hash, Clone, Debug)]
 pub enum Atom {
     Short(char),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -279,8 +279,8 @@ impl Parser {
         let opts =
             self.descs
             .find_mut(last_atom)
-            .expect(&format!("BUG: last opt desc key ('{:?}') is invalid.",
-                              last_atom));
+            .unwrap_or_else(|| panic!("BUG: last opt desc key ('{:?}') is invalid.",
+                                       last_atom));
         match opts.arg {
             One(None) => {}, // OK
             Zero =>

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -96,7 +96,7 @@ impl Parser {
 
     pub fn parse_argv(&self, argv: &[String], options_first: bool)
                          -> Result<Argv<'_>, String> {
-        Argv::new(self, &argv, options_first)
+        Argv::new(self, argv, options_first)
     }
 }
 

--- a/src/synonym.rs
+++ b/src/synonym.rs
@@ -59,7 +59,7 @@ impl<K: Eq + Hash, V> SynonymMap<K, V> {
 
 impl<K: Eq + Hash + Clone, V> SynonymMap<K, V> {
     pub fn resolve(&self, k: &K) -> K {
-        self.with_key(k, |k| k.clone())
+        self.with_key(k, std::clone::Clone::clone)
     }
 
     pub fn get<'a>(&'a self, k: &K) -> &'a V {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -74,7 +74,7 @@ Options:
 
 #[test]
 fn regression_issue_12() {
-    const USAGE: &'static str = "
+    const USAGE: &str = "
     Usage:
         whisper info <file>
         whisper update <file> <timestamp> <value>
@@ -100,7 +100,7 @@ fn regression_issue_12() {
 
 #[test]
 fn regression_issue_195() {
-    const USAGE: &'static str = "
+    const USAGE: &str = "
     Usage:
         slow [-abcdefghijklmnopqrs...]
     ";
@@ -119,7 +119,7 @@ fn regression_issue_219() {
         arg_param: Vec<String>,
     }
 
-    const USAGE: &'static str = "
+    const USAGE: &str = "
     Usage:
         encode [-v <type> <param>]...
     ";
@@ -132,7 +132,7 @@ fn regression_issue_219() {
 
 #[test]
 fn test_unit_struct() {
-    const USAGE: &'static str = "
+    const USAGE: &str = "
     Usage:
         cargo version [options]
 

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -78,7 +78,7 @@ fn run(args: Args) -> Result<(), String> {
                      .map(|(name, possibles)| {
                          let choices = Regex::new(r"[ \t]+")
                              .unwrap()
-                             .split(&**possibles)
+                             .split(possibles)
                              .map(|s| s.to_string())
                              .collect::<Vec<String>>();
                          (name.clone(), choices)

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -29,7 +29,7 @@ mod parse;
 #[allow(dead_code)]
 mod synonym;
 
-const USAGE: &'static str = "
+const USAGE: &str = "
 Usage: docopt-wordlist [(<name> <possibles>)] ...
 
 docopt-wordlist prints a list of available flags and commands arguments for the
@@ -71,7 +71,7 @@ fn main() {
 fn run(args: Args) -> Result<(), String> {
     let mut usage = String::new();
     io::stdin().read_to_string(&mut usage).map_err(|e| e.to_string())?;
-    let parsed = Parser::new(&usage).map_err(|e| e.to_string())?;
+    let parsed = Parser::new(&usage).map_err(|e| e)?;
     let arg_possibles: HashMap<String, Vec<String>> =
         args.arg_name.iter()
                      .zip(args.arg_possibles.iter())
@@ -89,7 +89,7 @@ fn run(args: Args) -> Result<(), String> {
     for k in parsed.descs.keys() {
         if let Atom::Positional(ref arg_name) = *k {
             if let Some(choices) = arg_possibles.get(arg_name) {
-                words.extend(choices.iter().map(|s| s.clone()));
+                words.extend(choices.iter().cloned());
             }
             // If the user hasn't given choices for this positional argument,
             // then there's really nothing to complete here.

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -62,7 +62,7 @@ fn main() {
     match run(args) {
         Ok(_) => {},
         Err(err) => {
-            write!(&mut io::stderr(), "{}", err).unwrap();
+            write!(&mut io::stderr(), "{err}").unwrap();
             ::std::process::exit(1)
         }
     }

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -79,7 +79,7 @@ fn run(args: Args) -> Result<(), String> {
                          let choices = Regex::new(r"[ \t]+")
                              .unwrap()
                              .split(possibles)
-                             .map(|s| s.to_string())
+                             .map(std::string::ToString::to_string)
                              .collect::<Vec<String>>();
                          (name.clone(), choices)
                      })

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -71,7 +71,7 @@ fn main() {
 fn run(args: Args) -> Result<(), String> {
     let mut usage = String::new();
     io::stdin().read_to_string(&mut usage).map_err(|e| e.to_string())?;
-    let parsed = Parser::new(&usage).map_err(|e| e)?;
+    let parsed = Parser::new(&usage)?;
     let arg_possibles: HashMap<String, Vec<String>> =
         args.arg_name.iter()
                      .zip(args.arg_possibles.iter())


### PR DESCRIPTION
as docopt.rs is no longer maintained, and we want to keep improving docopt, as qsv has fully embraced its self-documenting usage text syntax that neither clap nor structopt can provide.

